### PR TITLE
Feat/task/add tag

### DIFF
--- a/streamline/src/app/app.module.ts
+++ b/streamline/src/app/app.module.ts
@@ -78,3 +78,28 @@ const appRoutes: Routes = [
   entryComponents: [DeleteConfirmDialog, EditTagDialog, CreateTagDialog, EditTaskDialog, UnregisterDialog, AddTagDialog]
 })
 export class AppModule { }
+
+export interface Tag {
+  id: number,
+  name: string,
+  description: string,
+  tasks_comp: number,
+  average_time: number,
+  average_acc: number,
+  task_overunder: number,
+  color: string,
+  userID: number
+};
+
+export interface Task {
+  id: number;
+  title: string,
+  body: string,
+  workedDuration: number,
+  estimatedMin: number,
+  estimatedHour: number,
+  lastWorkedAt: number,
+  expDuration: number,
+  isFinished: number,
+  tags: Tag[]
+};

--- a/streamline/src/app/app.module.ts
+++ b/streamline/src/app/app.module.ts
@@ -19,7 +19,7 @@ import { AuthService } from './auth.service';
 import { TasksComponent } from './tasks/tasks.component';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { JwtInterceptor } from './jwt.interceptor';
-import { DialogsModule, DeleteConfirmDialog, EditTagDialog, CreateTagDialog, EditTaskDialog, UnregisterDialog } from './dialogs/dialogs.module';
+import { DialogsModule, DeleteConfirmDialog, EditTagDialog, CreateTagDialog, EditTaskDialog, UnregisterDialog, AddTagDialog } from './dialogs/dialogs.module';
 import { PasswordResetComponent } from './password-reset/password-reset.component';
 import { PasswordResetFormComponent } from './password-reset-form/password-reset-form.component';
 import { SettingsComponent } from './settings/settings.component';
@@ -52,6 +52,7 @@ const appRoutes: Routes = [
     EditTagDialog,
     EditTaskDialog,
     UnregisterDialog,
+    AddTagDialog,
     PasswordResetComponent,
     PasswordResetFormComponent,
     SettingsComponent,
@@ -74,6 +75,6 @@ const appRoutes: Routes = [
     {provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true}
   ],
   bootstrap: [AppComponent],
-  entryComponents: [DeleteConfirmDialog, EditTagDialog, CreateTagDialog, EditTaskDialog, UnregisterDialog]
+  entryComponents: [DeleteConfirmDialog, EditTagDialog, CreateTagDialog, EditTaskDialog, UnregisterDialog, AddTagDialog]
 })
 export class AppModule { }

--- a/streamline/src/app/backend.service.ts
+++ b/streamline/src/app/backend.service.ts
@@ -28,6 +28,7 @@ export class BackendService {
   public removeTagURL: string = 'http://' + this.root + '/api/tasks/removeTag';
   public deleteTaskURL: string = 'http://' + this.root + '/api/tasks/delete';
   public editTaskURL: string = 'http://' + this.root + '/api/tasks/update';
+  public addTagtoTaskURL: string = 'http://' + this.root + '/api/tasks/addTag';
 
   /* Task Control URLs */
   public startTaskURL: string = 'http://' + this.root + '/api/tasks/';
@@ -84,11 +85,18 @@ export class BackendService {
       .pipe(catchError(this.handleError));
   }
 
-  removeTag(taskID: number, tagID: number) {
-    return this.http.post(this.removeTagURL + '/' + taskID + '/' + tagID, httpOptions) //append taskID then tagID
+  removeTag(taskID: number, tagID: number): Observable<any> {
+    return this.http.put(this.removeTagURL + '/' + taskID + '/' + tagID, httpOptions) //append taskID then tagID
       .pipe(
         catchError(this.handleError)
       );
+  }
+
+  addTag(taskID: number, tagID: number): Observable<any> {
+    return this.http.put(this.addTagtoTaskURL + '/' + taskID + '/' + tagID, httpOptions)
+    .pipe(
+      catchError(this.handleError)
+    );
   }
 
   getTaskTags(taskID: number): Observable<Tag[]> {

--- a/streamline/src/app/backend.service.ts
+++ b/streamline/src/app/backend.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
-import { catchError, retry } from 'rxjs/operators';
+import { catchError } from 'rxjs/operators';
 import { HttpHeaders } from '@angular/common/http';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { MatSnackBar } from '@angular/material';
 import { AuthService } from './auth.service';
+import { Tag, Task } from './app.module'
 
 
 const httpOptions = {
@@ -263,33 +263,10 @@ export class BackendService {
   };
 }
 
-interface Task {
-  id: number;
-  title: string,
-  body: string,
-  workedDuration: number,
-  estimatedMin: number,
-  estimatedHour: number,
-  lastWorkedAt: number,
-  expDuration: number,
-  isFinished: number,
-  tags: Tag[]
-};
+
 interface Setting {
   theme: string
 }
-
-interface Tag {
-  id: number,
-  name: string,
-  description: string,
-  tasks_comp: number,
-  average_time: number,
-  average_acc: number,
-  task_overunder: number,
-  color: string,
-  userID: number
-};
 
 interface TagEdit {
   name: string,

--- a/streamline/src/app/create-task/create-task.component.ts
+++ b/streamline/src/app/create-task/create-task.component.ts
@@ -1,12 +1,13 @@
-import { Component, OnInit, Inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormGroup, FormControl } from '@angular/forms';
 import { BackendService } from '../backend.service';
 import { AuthService } from '../auth.service';
 import { Router } from '@angular/router';
-import { MatSnackBar, MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material';
+import { MatSnackBar, MatDialog } from '@angular/material';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
-import { CreateTagDialog, CreateTagDialogData } from '../dialogs/dialogs.module'
+import { CreateTagDialog } from '../dialogs/dialogs.module'
+import { Tag } from '../app.module'
 
 const MINUTES_TO_SECONDS: number = 60;
 const HOURS_TO_SECONDS: number = 3600;
@@ -175,15 +176,3 @@ export class CreateTaskComponent {
     return arr;
   }
 }
-
-interface Tag {
-  id: number,
-  name: string,
-  description: string,
-  tasks_comp: number,
-  average_time: number,
-  average_acc: number,
-  task_overunder: number,
-  color: string,
-  userID: number
-};

--- a/streamline/src/app/dialogs/add-tag/add-tag-dialog.css
+++ b/streamline/src/app/dialogs/add-tag/add-tag-dialog.css
@@ -1,0 +1,9 @@
+div.square {
+    margin-top: 12px;
+    margin-left: 8px;
+    margin-right: 8px;
+    height: 1.5em;
+    width: 3em;
+    float: left;
+  }
+ 

--- a/streamline/src/app/dialogs/add-tag/add-tag-dialog.html
+++ b/streamline/src/app/dialogs/add-tag/add-tag-dialog.html
@@ -1,4 +1,19 @@
-<div mat-dialog-actions class="button_box">
-        <button mat-button (click)="addTag()">Add</button>
-        <button mat-button (click)="closeDialog()">Cancel</button>
+<div class="row">
+    <div class="col-md-6">
+        <h4>Add a Tag</h4>
+        <mat-form-field>
+            <input matInput [matAutocomplete]="auto" [formControl]="rawTagsForm">
+            <mat-autocomplete #auto="matAutocomplete">
+                <mat-option *ngFor="let tag of filteredTags | async" (click)="onTagSelect(tag.id)" [value]="tag.name">
+                    <div class="square" [ngStyle]="{'background-color': tag.color}"></div> |
+                    <span>{{tag.name}}</span>
+                </mat-option>
+            </mat-autocomplete>
+        </mat-form-field>
     </div>
+</div>
+
+<div mat-dialog-actions class="button_box">
+    <button mat-button (click)="addTag()">Add</button>
+    <button mat-button (click)="closeDialog()">Cancel</button>
+</div>

--- a/streamline/src/app/dialogs/add-tag/add-tag-dialog.html
+++ b/streamline/src/app/dialogs/add-tag/add-tag-dialog.html
@@ -1,19 +1,17 @@
-<div class="row">
-    <div class="col-md-6">
-        <h4>Add a Tag</h4>
-        <mat-form-field>
-            <input matInput [matAutocomplete]="auto" [formControl]="rawTagsForm">
-            <mat-autocomplete #auto="matAutocomplete">
-                <mat-option *ngFor="let tag of filteredTags | async" (click)="onTagSelect(tag.id)" [value]="tag.name">
-                    <div class="square" [ngStyle]="{'background-color': tag.color}"></div> |
-                    <span>{{tag.name}}</span>
-                </mat-option>
-            </mat-autocomplete>
-        </mat-form-field>
-    </div>
+<h1 mat-dialog-title>Add a Tag</h1>
+<div mat-dialog-content class="diag_box">
+    <mat-form-field>
+        <mat-label>Tag Name</mat-label>
+        <input matInput [matAutocomplete]="auto" [formControl]="rawTagsForm">
+        <mat-autocomplete #auto="matAutocomplete">
+            <mat-option *ngFor="let tag of filteredTags | async" (click)="onTagSelect(tag.id)" [value]="tag.name">
+                <div class="square" [ngStyle]="{'background-color': tag.color}"></div> |
+                <span>{{tag.name}}</span>
+            </mat-option>
+        </mat-autocomplete>
+    </mat-form-field>
 </div>
-
-<div mat-dialog-actions class="button_box">
-    <button mat-button (click)="addTag()">Add</button>
-    <button mat-button (click)="closeDialog()">Cancel</button>
+<div mat-dialog-actions style="float: right;" class="button_box">
+    <button mat-button style="background-color: lightgreen;" (click)="addTag()">Add</button>
+    <button mat-button style="background-color: lightcoral;" (click)="closeDialog()">Cancel</button>
 </div>

--- a/streamline/src/app/dialogs/add-tag/add-tag-dialog.html
+++ b/streamline/src/app/dialogs/add-tag/add-tag-dialog.html
@@ -1,0 +1,4 @@
+<div mat-dialog-actions class="button_box">
+        <button mat-button (click)="addTag()">Add</button>
+        <button mat-button (click)="closeDialog()">Cancel</button>
+    </div>

--- a/streamline/src/app/dialogs/create-tag/create-tag-dialog.html
+++ b/streamline/src/app/dialogs/create-tag/create-tag-dialog.html
@@ -14,7 +14,7 @@
         <input matInput type="color" [(ngModel)]="data.color">
     </mat-form-field>
 </div>
-<div mat-dialog-actions class="button_box">
-    <button mat-button (click)="createTag()">Create</button>
-    <button mat-button (click)="closeDiag()">Cancel</button>
+<div mat-dialog-actions style="float: right;" class="button_box">
+    <button mat-button style="background-color: lightgreen;" (click)="createTag()">Add</button>
+    <button mat-button style="background-color: lightcoral;" (click)="closeDiag()">Cancel</button>
 </div>

--- a/streamline/src/app/dialogs/delete-confirm/delete-confirm-dialog.html
+++ b/streamline/src/app/dialogs/delete-confirm/delete-confirm-dialog.html
@@ -1,10 +1,8 @@
 <h1 mat-dialog-title>Delete Item</h1>
 <div mat-dialog-content class="diag_box">
-   <p>Are you sure you want to delete this Item?</p>
+    <p>Are you sure you want to delete this Item?</p>
 </div>
-<div mat-dialog-actions class="button_box">
-    <button mat-button (click)="yes()">Yes, Delete</button>
-    <button mat-button (click)="no()">No, Cancel</button>
+<div mat-dialog-actions style="float: right;" class="button_box">
+    <button mat-button style="background-color: lightgreen;" (click)="yes()">Add</button>
+    <button mat-button style="background-color: lightcoral;" (click)="no()">Cancel</button>
 </div>
-
-

--- a/streamline/src/app/dialogs/dialogs.module.ts
+++ b/streamline/src/app/dialogs/dialogs.module.ts
@@ -4,6 +4,8 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { Observable } from 'rxjs';
 import { FormControl } from '@angular/forms';
 import { Tag } from '../app.module'
+import { BackendService } from '../backend.service';
+import { startWith, map } from 'rxjs/operators';
 
 @NgModule({
   imports: [
@@ -16,6 +18,7 @@ export class DialogsModule { }
 @Component({
   selector: 'create-tag/create-tag-dialog',
   templateUrl: 'create-tag/create-tag-dialog.html',
+  styleUrls: ['create-tag/create-tag-dialog.css']
 })
 export class CreateTagDialog {
 
@@ -38,6 +41,8 @@ export class CreateTagDialog {
 @Component({
   selector: 'delete-confirm/delete-confirm-dialog',
   templateUrl: 'delete-confirm/delete-confirm-dialog.html',
+  styleUrls: ['delete-confirm/delete-confirm-dialog.css']
+
 })
 export class DeleteConfirmDialog {
 
@@ -55,6 +60,8 @@ export class DeleteConfirmDialog {
 @Component({
   selector: 'edit-tag/edit-tag-dialog',
   templateUrl: 'edit-tag/edit-tag-dialog.html',
+  styleUrls: ['edit-tag/edit-tag-dialog.css']
+
 })
 export class EditTagDialog {
   constructor(public dialogRef: MatDialogRef<EditTagDialog>,
@@ -72,6 +79,7 @@ export class EditTagDialog {
 @Component({
   selector: 'edit-task/edit-task-dialog',
   templateUrl: 'edit-task/edit-task-dialog.html',
+  styleUrls: ['edit-task/edit-task-dialog.css']
 })
 export class EditTaskDialog {
   constructor(public dialogRef: MatDialogRef<EditTaskDialog>,
@@ -91,30 +99,53 @@ export class EditTaskDialog {
 @Component({
   selector: 'add-tag/add-tag-dialog',
   templateUrl: 'add-tag/add-tag-dialog.html',
+  styleUrls: ['add-tag/add-tag-dialog.css']
 })
 export class AddTagDialog {
   public rawTagsForm: FormControl = new FormControl();
   public filteredTags: Observable<Tag[]>;
   public tags: Tag[];
 
-  constructor(public dialogRef: MatDialogRef<AddTagDialog>,
-    @Inject(MAT_DIALOG_DATA) public data: AddTagDialogData){}
+  constructor(
+    public dialogRef: MatDialogRef<AddTagDialog>,
+    private backend: BackendService,
+    @Inject(MAT_DIALOG_DATA) public data: AddTagDialogData) {
+    this.backend.getUserTags(this.data.userID).subscribe(res => {
+      if (res != null) {
+        this.tags = res;
+        //set up autofill for tags
+        this.filteredTags = this.rawTagsForm.valueChanges
+          .pipe(
+            startWith(''),
+            map(tag => tag ? this._filterTags(tag) : this.tags.slice())
+          );
+      }
+      else {
+        console.log('Could not retrieve tags');
+        this.dialogRef.close(-2); //TODO code this to give response to user?
+      }
+    })
+  }
 
-    addTag(){
+  addTag() {
+    this.dialogRef.close(this.data.tagID);
+  }
 
-    }
+  closeDialog() {
+    this.dialogRef.close(-1);
+  }
 
-    closeDialog(){
-      this.dialogRef.close();
-    }
+  public onTagSelect(tagID: number) {
+    this.data.tagID = tagID;
+  }
 
+  private _filterTags(value: string): Tag[] {
+    const filterValue = value.toLowerCase();
 
-    private _filterTags(value: string): Tag[] {
-      const filterValue = value.toLowerCase();
+    return this.tags.filter(tag => tag.name.toLowerCase().indexOf(filterValue) === 0);
+  }
+
   
-      return this.tags.filter(tag => tag.name.toLowerCase().indexOf(filterValue) === 0);
-    }
-
 }
 
 @Component({
@@ -124,7 +155,7 @@ export class AddTagDialog {
 export class UnregisterDialog {
 
   constructor(
-    public dialogRef: MatDialogRef<UnregisterDialog>) {}
+    public dialogRef: MatDialogRef<UnregisterDialog>) { }
 
   onNoClick(): void {
     this.dialogRef.close();
@@ -158,6 +189,7 @@ export interface EditTaskDialogData {
 };
 
 export interface AddTagDialogData {
-
+  userID: number,
+  tagID: number,
 };
 

--- a/streamline/src/app/dialogs/dialogs.module.ts
+++ b/streamline/src/app/dialogs/dialogs.module.ts
@@ -1,6 +1,9 @@
 import { NgModule, Component, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { Observable } from 'rxjs';
+import { FormControl } from '@angular/forms';
+import { Tag } from '../app.module'
 
 @NgModule({
   imports: [
@@ -90,16 +93,28 @@ export class EditTaskDialog {
   templateUrl: 'add-tag/add-tag-dialog.html',
 })
 export class AddTagDialog {
+  public rawTagsForm: FormControl = new FormControl();
+  public filteredTags: Observable<Tag[]>;
+  public tags: Tag[];
+
   constructor(public dialogRef: MatDialogRef<AddTagDialog>,
-    @Inject(MAT_DIALOG_DATA) public data: EditTagDialogData){}
+    @Inject(MAT_DIALOG_DATA) public data: AddTagDialogData){}
 
     addTag(){
-      alert('acknowledged!');
+
     }
 
     closeDialog(){
       this.dialogRef.close();
     }
+
+
+    private _filterTags(value: string): Tag[] {
+      const filterValue = value.toLowerCase();
+  
+      return this.tags.filter(tag => tag.name.toLowerCase().indexOf(filterValue) === 0);
+    }
+
 }
 
 @Component({
@@ -120,7 +135,6 @@ export class UnregisterDialog {
   }
 
 }
-
 
 export interface CreateTagDialogData {
   name: string,
@@ -145,4 +159,5 @@ export interface EditTaskDialogData {
 
 export interface AddTagDialogData {
 
-}
+};
+

--- a/streamline/src/app/dialogs/dialogs.module.ts
+++ b/streamline/src/app/dialogs/dialogs.module.ts
@@ -49,7 +49,6 @@ export class DeleteConfirmDialog {
   }
 }
 
-
 @Component({
   selector: 'edit-tag/edit-tag-dialog',
   templateUrl: 'edit-tag/edit-tag-dialog.html',
@@ -87,6 +86,23 @@ export class EditTaskDialog {
 }
 
 @Component({
+  selector: 'add-tag/add-tag-dialog',
+  templateUrl: 'add-tag/add-tag-dialog.html',
+})
+export class AddTagDialog {
+  constructor(public dialogRef: MatDialogRef<AddTagDialog>,
+    @Inject(MAT_DIALOG_DATA) public data: EditTagDialogData){}
+
+    addTag(){
+      alert('acknowledged!');
+    }
+
+    closeDialog(){
+      this.dialogRef.close();
+    }
+}
+
+@Component({
   selector: 'unregister-dialog',
   templateUrl: 'unregister/unregister-dialog.html',
 })
@@ -104,6 +120,8 @@ export class UnregisterDialog {
   }
 
 }
+
+
 export interface CreateTagDialogData {
   name: string,
   desc: string,
@@ -123,4 +141,8 @@ export interface EditTaskDialogData {
   estimatedMin: number,
   estimatedHour: number,
   expDuration: number
+};
+
+export interface AddTagDialogData {
+
 }

--- a/streamline/src/app/tags/tags.component.ts
+++ b/streamline/src/app/tags/tags.component.ts
@@ -1,22 +1,9 @@
-import { Component, OnInit, Inject } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { BackendService } from '../backend.service';
 import { MatDialog, MatSnackBar } from '@angular/material';
 import { AuthService } from '../auth.service';
 import { CreateTagDialog, EditTagDialog, DeleteConfirmDialog } from '../dialogs/dialogs.module';
 
-/*
-export interface CreateTagDialogData {
-  name: string,
-  desc: string,
-  color: string
-};
-
-export interface EditTagDialogData {
-  name: string,
-  desc: string,
-  color: string
-};
-*/
 @Component({
   selector: 'app-tags',
   templateUrl: './tags.component.html',
@@ -43,7 +30,7 @@ export class TagsComponent implements OnInit {
   }
 
   createTag() {
-    console.log('Hello Moto Tags');
+    //console.log('Hello Moto Tags');
     const dialogRef = this.create_dialog.open(CreateTagDialog, {
       width: '250px',
       data: { name: '', desc: '', color: "#c4c4c4" }
@@ -202,65 +189,6 @@ export class TagsComponent implements OnInit {
     });
   }
 }
-
-/*
-@Component({
-  selector: 'create-tag/create-tag-dialog',
-  templateUrl: 'create-tag/create-tag-dialog.html',
-})
-export class CreateTagDialog {
-
-  constructor(public dialogRef: MatDialogRef<CreateTagDialog>,
-    @Inject(MAT_DIALOG_DATA) public data: CreateTagDialogData) {
-
-  }
-
-  createTag() {
-    //close the dialog, data will be returned to parent component
-    this.dialogRef.close(this.data);
-  }
-
-  closeDiag() {
-    //return to parent component, result will be undefined
-    this.dialogRef.close();
-  }
-}
-
-@Component({
-  selector: 'delete-tag/delete-confirm-dialog',
-  templateUrl: 'delete-tag/delete-confirm-dialog.html',
-})
-export class DeleteConfirmDialog {
-
-  constructor(public dialogRef: MatDialogRef<DeleteConfirmDialog>) { }
-
-  yes() {
-    this.dialogRef.close(true); //return true to parent component
-  }
-
-  no() {
-    this.dialogRef.close(false); //return false to parent component
-  }
-}
-
-
-@Component({
-  selector: 'edit-tag/edit-dialog',
-  templateUrl: 'edit-tag/edit-dialog.html',
-})
-export class EditTagDialog {
-  constructor(public dialogRef: MatDialogRef<EditTagDialog>,
-    @Inject(MAT_DIALOG_DATA) public data: EditTagDialogData) { }
-
-  editTag() {
-    this.dialogRef.close(this.data); //return data fields to parent
-  }
-
-  closeDialog() {
-    this.dialogRef.close();
-  }
-}
-*/
 
 interface Tag {
   id: number,

--- a/streamline/src/app/tasks/tasks.component.html
+++ b/streamline/src/app/tasks/tasks.component.html
@@ -41,6 +41,9 @@
                 (click)="removeTag(task.id, tag.id)">
                 {{tag.name}}
               </li>
+              <li (click)="addTag(task.id)">
+              +<!-- causes weird alignment issues  <mat-icon style="width: 30px;height: 30px;">add</mat-icon> -->
+              </li>
             </ul>
           </div>
         </div>

--- a/streamline/src/app/tasks/tasks.component.html
+++ b/streamline/src/app/tasks/tasks.component.html
@@ -41,7 +41,7 @@
                 (click)="removeTag(task.id, tag.id)">
                 {{tag.name}}
               </li>
-              <li (click)="addTag(task.id)">
+              <li (click)="addTag(task)">
               +<!-- causes weird alignment issues  <mat-icon style="width: 30px;height: 30px;">add</mat-icon> -->
               </li>
             </ul>
@@ -72,7 +72,6 @@
           </button>
         </div>
       </div>
-      <!-- Removed until implementation of subtasks feature -->
       <div id="content_{{task.id}}" style="padding: 0 18px; display: none; overflow: hidden; height: 200px;">
         <div class="row">
           <div class="col-md-6"

--- a/streamline/src/app/tasks/tasks.component.ts
+++ b/streamline/src/app/tasks/tasks.component.ts
@@ -69,20 +69,6 @@ export class TasksComponent implements OnInit {
       });
 
     });
-    /*
-      var count = 0;
-      this.tasks.forEach(task => {
-        this.backend.getTaskTags(task.id).subscribe(res => {
-          console.log('tags retrieved for task ' + task.id + ':');
-          console.log(res);
-  
-          this.tasks[count].tags = res;
-          console.log(this.tasks[count].tags);
-  
-          count++;
-        });
-      });
-    */
   }
 
   removeTag(taskID: number, tagID: number) {
@@ -114,10 +100,28 @@ export class TasksComponent implements OnInit {
   addTag(taskID: number) {
     const dialogRef = this.create_dialog.open(AddTagDialog, {
       width: '325px',
+      data: { tagID: -1, userID: this.auth.getUserId() }
     });
 
+    dialogRef.afterClosed().subscribe(result => {
+      if (result >= 0) {
+        var tagID = result;
 
+        this.backend.addTag(taskID, tagID).subscribe(res => {
+          //three second snackbar pop up notification
+          let snackbarRef = this.snackbar.open('Tag added to that Task!', 'Ok', { duration: 3000 });
 
+          this.getTaskTags(taskID);
+        },
+          error => {
+            console.log(error.message);
+            //three second snackbar pop up notification
+            let snackbarRef = this.snackbar.open('Oh no, something went wrong!', 'Ok', { duration: 3000 });
+          }
+        );
+      }
+      else { /* do nothing for now */ }
+    });
   }
 
   deleteTask(task: Task) {

--- a/streamline/src/app/tasks/tasks.component.ts
+++ b/streamline/src/app/tasks/tasks.component.ts
@@ -97,7 +97,7 @@ export class TasksComponent implements OnInit {
     });
   }
 
-  addTag(taskID: number) {
+  addTag(task: Task) {
     const dialogRef = this.create_dialog.open(AddTagDialog, {
       width: '325px',
       data: { tagID: -1, userID: this.auth.getUserId() }
@@ -106,19 +106,31 @@ export class TasksComponent implements OnInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result >= 0) {
         var tagID = result;
+        let exists: boolean = false;
+        console.log(task.tags);
 
-        this.backend.addTag(taskID, tagID).subscribe(res => {
-          //three second snackbar pop up notification
-          let snackbarRef = this.snackbar.open('Tag added to that Task!', 'Ok', { duration: 3000 });
-
-          this.getTaskTags(taskID);
-        },
-          error => {
-            console.log(error.message);
+        task.tags.forEach(t => {
+          if (t.id === tagID) { //if this task already has that tag, don't add it
             //three second snackbar pop up notification
-            let snackbarRef = this.snackbar.open('Oh no, something went wrong!', 'Ok', { duration: 3000 });
+            let snackbarRef = this.snackbar.open('That Task already has that Tag!', 'Ok', { duration: 3000 });
+            exists = true;
           }
-        );
+        });
+
+        if (!exists) {
+          this.backend.addTag(task.id, tagID).subscribe(res => {
+            //three second snackbar pop up notification
+            let snackbarRef = this.snackbar.open('Tag added to that Task!', 'Ok', { duration: 3000 });
+
+            this.getTaskTags(task.id);
+          },
+            error => {
+              console.log(error.message);
+              //three second snackbar pop up notification
+              let snackbarRef = this.snackbar.open('Oh no, something went wrong!', 'Ok', { duration: 3000 });
+            }
+          );
+        }
       }
       else { /* do nothing for now */ }
     });

--- a/streamline/src/app/tasks/tasks.component.ts
+++ b/streamline/src/app/tasks/tasks.component.ts
@@ -3,7 +3,7 @@ import { BackendService } from '../backend.service';
 import { AuthService } from '../auth.service';
 import { MatSnackBar, MatDialog } from '@angular/material';
 import { Router } from '@angular/router';
-import { DeleteConfirmDialog, EditTaskDialog } from '../dialogs/dialogs.module';
+import { DeleteConfirmDialog, EditTaskDialog, AddTagDialog } from '../dialogs/dialogs.module';
 
 @Component({
   selector: 'app-tasks',
@@ -60,45 +60,63 @@ export class TasksComponent implements OnInit {
       console.log(res);
 
       var count = 0;
-      this.tasks.forEach(t =>{
-        if(t.id === taskID){
+      this.tasks.forEach(t => {
+        if (t.id === taskID) {
           this.tasks[count].tags = res;
         }
         count++;
       });
-      
+
     });
     /*
-    var count = 0;
-    this.tasks.forEach(task => {
-      this.backend.getTaskTags(task.id).subscribe(res => {
-        console.log('tags retrieved for task ' + task.id + ':');
-        console.log(res);
-
-        this.tasks[count].tags = res;
-        console.log(this.tasks[count].tags);
-
-        count++;
+      var count = 0;
+      this.tasks.forEach(task => {
+        this.backend.getTaskTags(task.id).subscribe(res => {
+          console.log('tags retrieved for task ' + task.id + ':');
+          console.log(res);
+  
+          this.tasks[count].tags = res;
+          console.log(this.tasks[count].tags);
+  
+          count++;
+        });
       });
-    });
     */
   }
 
   removeTag(taskID: number, tagID: number) {
-    this.backend.removeTag(taskID, tagID).subscribe(res => {
-      console.log('TagID ' + tagID + ' removed From TaskID' + taskID);
+    const dialogRef = this.create_dialog.open(DeleteConfirmDialog, {
+      width: '325px',
+    });
 
-      //three second snackbar pop up notification
-      let snackbarRef = this.snackbar.open('Tag removed from that task!', 'Ok', { duration: 3000 });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) { //if confirmed, delete
+        this.backend.removeTag(taskID, tagID).subscribe(res => {
+          console.log('TagID ' + tagID + ' removed From TaskID' + taskID);
 
-      //reload tags
-      this.getTaskTags(taskID);
-    },
-      error => {
-        console.log(error.message);
-        //three second snackbar pop up notification
-        let snackbarRef = this.snackbar.open('Oh no, something went wrong!', 'Ok', { duration: 3000 });
-      });
+          //three second snackbar pop up notification
+          let snackbarRef = this.snackbar.open('Tag removed from that task!', 'Ok', { duration: 3000 });
+
+          //reload tags
+          this.getTaskTags(taskID);
+        },
+          error => {
+            console.log(error.message);
+            //three second snackbar pop up notification
+            let snackbarRef = this.snackbar.open('Oh no, something went wrong!', 'Ok', { duration: 3000 });
+          });
+      }
+      else { /* do nothing */ }
+    });
+  }
+
+  addTag(taskID: number) {
+    const dialogRef = this.create_dialog.open(AddTagDialog, {
+      width: '325px',
+    });
+
+
+
   }
 
   deleteTask(task: Task) {
@@ -228,19 +246,19 @@ export class TasksComponent implements OnInit {
     });
   }
 
-  getMinutes(seconds: number): number{
+  getMinutes(seconds: number): number {
     var hrs = 0;
-    if(seconds > 3600)
+    if (seconds > 3600)
       hrs = Math.floor(seconds / 3600);
-    
+
     var min = (seconds - (hrs * 3600)) / 60;
     return Math.floor(min);
   }
 
-  getHours(seconds: number) : number{
-    if(seconds > 3600)
+  getHours(seconds: number): number {
+    if (seconds > 3600)
       return Math.floor(seconds / 3600);
-    else 
+    else
       return 0;
   }
 

--- a/streamline/src/app/tasks/tasks.component.ts
+++ b/streamline/src/app/tasks/tasks.component.ts
@@ -1,9 +1,10 @@
-import { Component, OnInit, Inject } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { BackendService } from '../backend.service';
 import { AuthService } from '../auth.service';
 import { MatSnackBar, MatDialog } from '@angular/material';
 import { Router } from '@angular/router';
 import { DeleteConfirmDialog, EditTaskDialog, AddTagDialog } from '../dialogs/dialogs.module';
+import { Tag, Task } from '../app.module'
 
 @Component({
   selector: 'app-tasks',
@@ -278,27 +279,4 @@ export class TasksComponent implements OnInit {
 
 }
 
-interface Task {
-  id: number;
-  title: string,
-  body: string,
-  workedDuration: number,
-  estimatedMin: number,
-  estimatedHour: number,
-  lastWorkedAt: number,
-  expDuration: number,
-  isFinished: number,
-  tags: Tag[]
-};
 
-interface Tag {
-  id: number,
-  name: string,
-  description: string,
-  tasks_comp: number,
-  average_time: number,
-  average_acc: number,
-  task_overunder: number,
-  color: string,
-  userID: number
-};


### PR DESCRIPTION
[STREAM-50] Add a Tag to a Task

**Main Features**
- Users can now add an existing tag to an existing task
  - Done with a Add-Tag dialog with an autocomplete input similar to what's in the create-task 
     component, but is restricted to only one tag at a time
- Client has checks to ensure that duplicate tags cannot be added to the same task
- Client updates with new list of tags once a new one is added

**Other Changes**
- Moved Tag,Task interfaces to app.module.ts so other components can import them from there rather than having their own copy in each file
- Fixed some alignment issues with the buttons in the dialog boxes, also added colors to the buttons to make them easier to differentiate 
- Changed delete-tag http request to a PUT rather than POST, this is reflected in the corresponding API PR 
