### PR TITLE
User Story 3 (Undo Task Deletion)

### DIFF
--- a/streamline/src/app/tags/tags.component.html
+++ b/streamline/src/app/tags/tags.component.html
@@ -48,6 +48,6 @@
       <div class="square" [ngStyle]="{'background-color': selectedTag.color}"></div>
     </div>
     <button mat-stroked-button class="edit_button" (click)="editTag(selectedTag)">Edit Tag</button>
-    <button mat-stroked-button class="del_button" (click)="deleteTag(selectedTag.id)" [disabled]="displayed_tags === prio_tags">Delete Tag</button>
+    <button mat-stroked-button class="del_button" (click)="deleteTag(selectedTag)" [disabled]="displayed_tags === prio_tags">Delete Tag</button>
   </mat-sidenav>
 </mat-sidenav-container>

--- a/streamline/src/app/tags/tags.component.ts
+++ b/streamline/src/app/tags/tags.component.ts
@@ -228,28 +228,45 @@ export class TagsComponent implements OnInit {
     }
   }
 
-  deleteTag(id: number) {
+  deleteTag(tag: Tag) {
     const dialogRef = this.create_dialog.open(DeleteConfirmDialog, {
       width: '325px',
     });
 
     dialogRef.afterClosed().subscribe(result => {
       if (result) { //if confirmed, delete
-        this.backend.deleteTag(id).subscribe(result => {
-          console.log(result);
+        //get index of tag
+        const index = this.tags.indexOf(tag);
 
-          //three second snackbar pop up notification
-          let snackbarRef = this.snackbar.open('Tag Deleted!', 'Ok', { duration: 3000 });
+        //splice tag out of list
+        this.tags.splice(index, 1);
 
-          //update display
-          this.loadData();
+        //close detail sidebar
+        this.opened = false;
 
-          //close sidebar showing deleted tags details
-          this.opened = false;
-        }, error => {
-          console.log(error.message);
-          //three second snackbar pop up notification
-          let snackbarRef = this.snackbar.open('Oh no, something went wrong!', 'Ok', { duration: 3000 });
+        //pop-up to allow user to undo action
+        let snackbarRef = this.snackbar.open('Tag Deleted!', 'Undo', { duration: 3000 });
+
+        //if action selected, splice tag back into the list
+        snackbarRef.onAction().subscribe(() => {
+          console.log('tag was not deleted (undo action)');
+          this.tags.splice(index, 0, tag);
+        });
+
+        //if action not selected before snackbar is dismissed, send DELETE request to backend
+        snackbarRef.afterDismissed().subscribe(res => {
+          if (!res.dismissedByAction) {
+            this.backend.deleteTag(tag.id).subscribe(() => {
+              console.log('tag was deleted from DB');
+            }, error => {
+              console.log(error.message);
+              //three second snackbar pop up notification
+              let snackbarRef = this.snackbar.open('Oh no, something went wrong!', 'Ok', { duration: 3000 });
+
+              //add tag back into list
+              this.tags.splice(index, 0, tag);
+            });
+          }
         });
       }
       else { /*do nothing */ }

--- a/streamline/src/app/tasks/tasks.component.ts
+++ b/streamline/src/app/tasks/tasks.component.ts
@@ -209,8 +209,8 @@ export class TasksComponent {
           //reload tags
           this.getTaskTags(taskID);
 
-           //maintain sort option
-           this.checkSort();
+          //maintain sort option
+          this.checkSort();
         },
           error => {
             console.log(error.message);
@@ -269,20 +269,34 @@ export class TasksComponent {
 
     dialogRef.afterClosed().subscribe(result => {
       if (result) { //if confirmed, delete
-        this.backend.deleteTask(task.id).subscribe(res => {
-          console.log(res);
+        const index = this.tasks.indexOf(task);
 
-          //three second snackbar pop up notification
-          let snackbarRef = this.snackbar.open('Task deleted!', 'Ok', { duration: 3000 });
+        this.tasks.splice(index, 1);
 
-          //reload tasks
-          this.getUserTasks();
-        },
-          error => {
-            console.log(error.message);
-            //three second snackbar pop up notification
-            let snackbarRef = this.snackbar.open('Oh no, something went wrong!', 'Ok', { duration: 3000 });
-          });
+        let snackbarRef = this.snackbar.open('Task deleted!', 'Undo', { duration: 3000 });
+        snackbarRef.afterDismissed().subscribe(res => {
+          if (res.dismissedByAction) {
+            //undo
+            console.log('delete undone!');
+            this.tasks.splice(index, 0, task);
+          }
+          else {
+            //delete
+            this.backend.deleteTask(task.id).subscribe(res => {
+              console.log('DELETE sent');
+
+              //three second snackbar pop up notification
+
+              //reload tasks
+              //          this.getUserTasks();
+            },
+              error => {
+                console.log(error.message);
+                //three second snackbar pop up notification
+                let snackbarRef = this.snackbar.open('Oh no, something went wrong!', 'Ok', { duration: 3000 });
+              });
+          }
+        });
       }
       else { /*do nothing */ }
     });

--- a/streamline/src/app/tasks/tasks.component.ts
+++ b/streamline/src/app/tasks/tasks.component.ts
@@ -269,31 +269,35 @@ export class TasksComponent {
 
     dialogRef.afterClosed().subscribe(result => {
       if (result) { //if confirmed, delete
+
+        //get index of the task
         const index = this.tasks.indexOf(task);
 
+        //remove task from task list displayed
         this.tasks.splice(index, 1);
 
+        //snackbar pop-up to give user option to undo
         let snackbarRef = this.snackbar.open('Task deleted!', 'Undo', { duration: 3000 });
+
+        //if user chooses to undo, splice task back to where it was in the list
+        snackbarRef.onAction().subscribe(res => {
+          console.log('tasks: task was not deleted (undo action)');
+          this.tasks.splice(index, 0, task);
+        });
+
+        //after snackbar is dimissed, check to see if action was done
         snackbarRef.afterDismissed().subscribe(res => {
-          if (res.dismissedByAction) {
-            //undo
-            console.log('delete undone!');
-            this.tasks.splice(index, 0, task);
-          }
-          else {
-            //delete
+          if (!res.dismissedByAction) { //only delete if action wasn't done
             this.backend.deleteTask(task.id).subscribe(res => {
-              console.log('DELETE sent');
-
-              //three second snackbar pop up notification
-
-              //reload tasks
-              //          this.getUserTasks();
+              console.log('delete request sent');
             },
               error => {
                 console.log(error.message);
                 //three second snackbar pop up notification
                 let snackbarRef = this.snackbar.open('Oh no, something went wrong!', 'Ok', { duration: 3000 });
+
+                //add task back into list
+                this.tasks.splice(index, 0, task);
               });
           }
         });


### PR DESCRIPTION
**Main Features**
- Users now have the option to undo deleting a task
    - The snackbar pop-up now has an 'undo' option that will add the Task back to the list client-side
    - If the undo action is selected, it will prevent the DELETE request from being sent
    - If the snackbar's duration expires before undo is selected, then the function proceeds to send the 
      DELETE request to have it deleted permanently 

**Additional Feature**
- I expanded this functionality to the Tags display as well, since it was trivial to do so